### PR TITLE
Copy url menu

### DIFF
--- a/ipc/consumer.js
+++ b/ipc/consumer.js
@@ -40,6 +40,9 @@ module.exports = function (commandId, args = {}) {
           })
         }
       }).catch(err => console.log(err))
+    case 'copyUrl':
+      BrowserWindow.getFocusedWindow().webContents.send('copy-url')
+      break
     default:
       break
   }

--- a/ipc/exec.js
+++ b/ipc/exec.js
@@ -1,0 +1,15 @@
+const { ipcMain, ipcRenderer } = require('electron')
+
+const consumer = require('./consumer')
+
+const isMainProcess = typeof ipcMain !== 'undefined'
+
+const exec = (commandId, args = {}) => {
+  if (isMainProcess) {
+    consumer(commandId, args)
+  } else {
+    ipcRenderer.send('main:command', { commandId, args })
+  }
+}
+
+module.exports = exec

--- a/menu.js
+++ b/menu.js
@@ -47,6 +47,12 @@ const template = [
         role: 'copy'
       },
       {
+        label: 'Copy URL',
+        click () {
+          exec('copyUrl')
+        }
+      },
+      {
         role: 'paste'
       },
       {

--- a/menu.js
+++ b/menu.js
@@ -1,4 +1,3 @@
-const { ipcMain, ipcRenderer } = require('electron')
 const path = require('path')
 const url = require('url')
 const os = require('os')
@@ -6,18 +5,8 @@ const os = require('os')
 const Menu = require('electron').Menu || require('electron').remote.Menu
 const app = require('electron').app || require('electron').remote.app
 
-const consumer = require('./ipc/consumer')
 const { getServerUrl } = require('./utils')
-
-const isMainProcess = typeof ipcMain !== 'undefined'
-
-function exec (commandId, args = {}) {
-  if (isMainProcess) {
-    consumer(commandId, args)
-  } else {
-    ipcRenderer.send('main:command', { commandId, args })
-  }
-}
+const exec = require('./ipc/exec')
 
 const template = [
   {


### PR DESCRIPTION
### Changes

- extract `exec` method out of menu.js
- Add `copyUrl` menu item both in application menu and navbar right click menu

![screen shot 2017-03-23 at 11 45 38 pm](https://cloud.githubusercontent.com/assets/4230968/24256320/da8d0cf2-1022-11e7-8405-c7721c70ca95.png)

![screen shot 2017-03-23 at 11 45 56 pm](https://cloud.githubusercontent.com/assets/4230968/24256332/e3a1d0f2-1022-11e7-95fb-2830991d4dfa.png)
