### PR TITLE
Modified app.css

### DIFF
--- a/app.css
+++ b/app.css
@@ -100,10 +100,11 @@ navbar.unsupported {
 	font-family: "Courier New", Courier, monospace;
   position: absolute;
   top: -11px;
-  transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) .3s;
+  transition: all cubic-bezier(0.165, 0.84, 0.44, 1) .3s;
   right: 20px;
   box-sizing: border-box;
   height: 40px;
+  opacity: 0;
 }
 
 .electronSearchText-input {
@@ -124,4 +125,5 @@ navbar.unsupported {
 .electronSearchText-visible {
   transform: translateY(33px);
   display: block;
+  opacity: 1;
 }

--- a/app.css
+++ b/app.css
@@ -105,6 +105,7 @@ navbar.unsupported {
   box-sizing: border-box;
   height: 40px;
   opacity: 0;
+  visibility: hidden;
 }
 
 .electronSearchText-input {
@@ -126,4 +127,5 @@ navbar.unsupported {
   transform: translateY(33px);
   display: block;
   opacity: 1;
+  visibility: visible;
 }


### PR DESCRIPTION
In the previous version , when switching to fullscreen mode ,
the search box would show however.

This is caused by the nav bar taking space in non-fullscreen ,
but hidden in full screen mode, cause the css to be buggy.

Modified transition of .electronSearchText-box to all 
Add opacity 0 ,visibility to .electronSearchText-visible

之前打開桌面版的時候，從視窗模式切換到全銀幕時

搜尋框會莫名其妙的跳出來，原因是在視窗模式的 navbar 是有佔空間的

在全銀幕時css的padding會不太對

要完全更改的話可能要偵測是否為全銀幕模式，再根據狀態改search bar的padding

不過這樣要改的code有點多，我只有改成在nav bar未顯示時多一個opacity 0以及visibility hidden(這樣就點不到了)

基本上在全銀幕時就不會有跑出來的問題了

